### PR TITLE
Fix: support system that overload Actor.create

### DIFF
--- a/modules/moulinette-dropas-actor.js
+++ b/modules/moulinette-dropas-actor.js
@@ -78,7 +78,7 @@ export class MoulinetteDropAsActor extends FormApplication {
 
       // extracts the filename and replace all filename separators by spaces
       const name = this.data.img.split("/").pop().split(".")[0].replaceAll("_", " ").replaceAll("-", " ").replace(/  +/g, ' ');
-      actor = await Actor.create({
+      actor = await getDocumentClass("Actor").create({
         name: name,
         type: actorType,
         img: this.data.img

--- a/modules/moulinette-prefabs.js
+++ b/modules/moulinette-prefabs.js
@@ -199,7 +199,7 @@ export class MoulinettePrefabs extends game.moulinette.applications.MoulinetteFo
       // Create actor
       const actorData = JSON.parse(jsonAsText)
       actorData.folder = await MoulinettePrefabs.getOrCreateActorFolder(pack.publisher, pack.name)
-      const actor = await Actor.create(actorData);
+      const actor = await getDocumentClass("Actor").create(actorData);
       
       // Prepare the Token data
       let tokenData


### PR DESCRIPTION
getDocumentClass("Actor") allows to get the actual Actor-derived class

See:
https://foundryvtt.com/api/global.html#getDocumentClass

Change-Id: I865c85be0acc7eeb2e3361ec7f924832af0a798d